### PR TITLE
Turn off backlights when toggling power.

### DIFF
--- a/EleksTubeHAX/Backlights.cpp
+++ b/EleksTubeHAX/Backlights.cpp
@@ -14,6 +14,8 @@ void Backlights::begin(StoredConfig::Config::Backlights *config_)  {
     setBreathRate(10);
     config->is_valid = StoredConfig::valid;
   }
+
+  off = false;
 }
 
 
@@ -51,7 +53,7 @@ void Backlights::setIntensity(uint8_t intensity) {
 
 void Backlights::loop() {
   //   enum patterns { dark, test, constant, rainbow, pulse, breath, num_patterns };
-  if (config->pattern == dark) {
+  if (off || config->pattern == dark) {
     if (pattern_needs_init) {
       clear();
       show();

--- a/EleksTubeHAX/Backlights.h
+++ b/EleksTubeHAX/Backlights.h
@@ -18,7 +18,7 @@
 
 class Backlights: public Adafruit_NeoPixel {
 public:
-  Backlights() : config(NULL), pattern_needs_init(true),
+  Backlights() : config(NULL), pattern_needs_init(true), off(true),
     Adafruit_NeoPixel(NUM_DIGITS, BACKLIGHTS_PIN, NEO_GRB + NEO_KHZ800)
     {}
 
@@ -27,6 +27,8 @@ public:
 
   void begin(StoredConfig::Config::Backlights *config_);
   void loop();
+
+  void togglePower() { off = !off; pattern_needs_init = true; }
 
   void setPattern(patterns p)      { config->pattern = uint8_t(p); pattern_needs_init = true; }
   patterns getPattern()            { return patterns(config->pattern); }
@@ -52,6 +54,7 @@ public:
   
 private:
   bool pattern_needs_init;
+  bool off;
 
   // Pattern configs, get backed up.
   StoredConfig::Config::Backlights *config;

--- a/EleksTubeHAX/EleksTubeHAX.ino
+++ b/EleksTubeHAX/EleksTubeHAX.ino
@@ -83,6 +83,7 @@ void loop() {
   // Power button
   if (buttons.power.isDownEdge()) {
     tfts.toggleAllDisplays();
+    backlights.togglePower();
   }
 
   // Update the clock.


### PR DESCRIPTION
I recognize that this _could_ be configured as an option quite easily, but I think off means off is a reasonable behavior.

(It also matches that of the original firmware.)