### PR TITLE
Fix uncapitalised filename and mention previously unmentioned required lib in readme

### DIFF
--- a/EleksTubeHAX/EleksTubeHAX.ino
+++ b/EleksTubeHAX/EleksTubeHAX.ino
@@ -15,7 +15,7 @@
 #include "Menu.h"
 #include "StoredConfig.h"
 #include "WiFi_WPS.h"
-#include "mqtt_client_ips.h"
+#include "Mqtt_client_ips.h"
 
 Backlights backlights;
 Buttons buttons;

--- a/EleksTubeHAX/Mqtt_client_ips.cpp
+++ b/EleksTubeHAX/Mqtt_client_ips.cpp
@@ -10,7 +10,7 @@
  * Documentation: https://www.docu.smartnest.cz/
  */
 
-#include "mqtt_client_ips.h"
+#include "Mqtt_client_ips.h"
 #include "WiFi.h"       // for ESP32
 #include <PubSubClient.h>  // Download and install this library first from: https://www.arduinolibraries.info/libraries/pub-sub-client
 

--- a/EleksTubeHAX/TFTs.cpp
+++ b/EleksTubeHAX/TFTs.cpp
@@ -1,6 +1,6 @@
 #include "TFTs.h"
 #include "WiFi_WPS.h"
-#include "mqtt_client_ips.h"
+#include "Mqtt_client_ips.h"
 
 void TFTs::begin() {
   // Start with all displays selected.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Sketch -> Include Library -> Library Manager
 * `TFT_eSPI` by Bodmer (developed on v2.3.61)
 * `Time` by Michael Margolis (developed on v1.6.0)
 * `PubSubClient` by Nick O'Leary (developed on v2.8.0)  https://www.arduinolibraries.info/libraries/pub-sub-client
+* `ArduinoJson` by Benoit Blanchon (worked on 6.19.4)
+
 For "SI HAI clock" also add:
 * RTC by Makuna (developed on 2.3.5) https://github.com/Makuna/Rtc/wiki
 


### PR DESCRIPTION
On Linux at least I was unable to compile this without correcting the capitalisation of Mqtt_client_ips.cpp.

And ArduinoJson wasn't mentioned in the readme as a required lib but is needed for the IP geolocation.