### PR TITLE
Fix for Arduino ESP32 version 2.0.7 causes crash on non-void functions

### DIFF
--- a/EleksTubeHAX/Clock.cpp
+++ b/EleksTubeHAX/Clock.cpp
@@ -6,7 +6,7 @@
   #include <RtcDS1302.h>
   ThreeWire myWire(DS1302_IO, DS1302_SCLK, DS1302_CE); // IO, SCLK, CE
   RtcDS1302<ThreeWire> Rtc(myWire);
-  uint32_t RtcBegin() {
+  void RtcBegin() {
     Rtc.Begin();
     // check if chip is connected and alive
 /*  TCS default value is 0x00 instead of 0x5C, but RTC seems to be working. Let's skip this check.

--- a/EleksTubeHAX/IPGeolocation_AO.cpp
+++ b/EleksTubeHAX/IPGeolocation_AO.cpp
@@ -146,6 +146,7 @@ bool IPGeolocation::updateStatus(IPGeo *I){
     DEBUGPRINT(I->tz);
     DEBUGPRINT("Geo Current Time: ");
     DEBUGPRINT(I->current_time);
+    return true;
   }
   else {
     /*  UNIFINISHED BUGGY CODE
@@ -212,4 +213,6 @@ bool IPGeolocation::updateStatus(IPGeo *I){
     DEBUGPRINT(dst_savings);
   */
   }
+  return false;
+
 }


### PR DESCRIPTION
With Arduino ESP32 version 2.0.7 (possibly 2.0.x) I noticed the compiler does not generate a warning or error for non-void functions that actually don't return a value. But the compiled code crashes or goes into a bootloop.

This was not a problem with Arduino ESP32 version 1.x.x

Anyway, changed 2 files, adding a return where needed. 