### PR TITLE
Improve menu experience and allow bitmap dimming

### DIFF
--- a/EleksTubeHAX_pio/src/Backlights.cpp
+++ b/EleksTubeHAX_pio/src/Backlights.cpp
@@ -179,7 +179,7 @@ void Backlights::rainbowPattern() {
     setPixelColor(digit, phaseToColor(my_phase));
   }
   if (dimming) {
-    setBrightness((uint8_t) BACKLIGHT_DIMMED_INTENSITY);
+    setBrightness(0xFF >> max_intensity - (uint8_t) BACKLIGHT_DIMMED_INTENSITY - 1);
   }  else {
     setBrightness(0xFF >> max_intensity - config->intensity - 1);  
   }

--- a/EleksTubeHAX_pio/src/Clock.h
+++ b/EleksTubeHAX_pio/src/Clock.h
@@ -35,9 +35,15 @@ public:
   void toggleBlankHoursZero()           { config->blank_hours_zero = !config->blank_hours_zero; }
 
   // Internal time is kept in UTC. This affects the displayed time.
-  void setTimeZoneOffset(time_t offset) { config->time_zone_offset = offset; }
+  void setTimeZoneOffset(time_t offset) { 
+    config->time_zone_offset = offset; 
+    loop();
+  }
   time_t getTimeZoneOffset()            { return config->time_zone_offset; }
-  void adjustTimeZoneOffset(time_t adj) { config->time_zone_offset += adj; }
+  void adjustTimeZoneOffset(time_t adj) { 
+    config->time_zone_offset += adj;
+    loop();
+  }
   void  setActiveGraphicIdx(int8_t idx) { config->selected_graphic = idx;}
   int8_t getActiveGraphicIdx()          { return config->selected_graphic; }
   void adjustClockGraphicsIdx(int8_t adj) {

--- a/EleksTubeHAX_pio/src/Clock.h
+++ b/EleksTubeHAX_pio/src/Clock.h
@@ -41,14 +41,19 @@ public:
   void  setActiveGraphicIdx(int8_t idx) { config->selected_graphic = idx;}
   int8_t getActiveGraphicIdx()          { return config->selected_graphic; }
   void adjustClockGraphicsIdx(int8_t adj) {
-    config->selected_graphic += adj;
-    if (config->selected_graphic > tfts.NumberOfClockFaces) { config->selected_graphic = tfts.NumberOfClockFaces; }
-    if (config->selected_graphic < 1) { config->selected_graphic = 1; }   
+    int8_t newGraphic = getActiveGraphicIdx();
+    newGraphic += adj;
+    
+    if (newGraphic > tfts.NumberOfClockFaces) { newGraphic = 1; }
+    if (newGraphic < 1) { newGraphic = tfts.NumberOfClockFaces; }   
+
+    this->setClockGraphicsIdx(newGraphic);
   }
   void setClockGraphicsIdx(int8_t set) {
-    config->selected_graphic = set;
-    if (config->selected_graphic > tfts.NumberOfClockFaces) { config->selected_graphic = tfts.NumberOfClockFaces; }
-    if (config->selected_graphic < 1) { config->selected_graphic = 1; }   
+    if (set > tfts.NumberOfClockFaces) { set = tfts.NumberOfClockFaces; }
+    if (set < 1) { set = 1; }  
+
+    config->selected_graphic = set; 
   }
 
   // Proxy C functions from TimeLib.h

--- a/EleksTubeHAX_pio/src/TFTs.cpp
+++ b/EleksTubeHAX_pio/src/TFTs.cpp
@@ -289,17 +289,13 @@ bool TFTs::LoadImageIntoBuffer(uint8_t file_index) {
           }
           b = c; g = c >> 8; r = c >> 16;
         }
-/* BUG: this does not work yet        
+
+        uint16_t color = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xFF) >> 3);
         if (dimming < 255) { // only dim when needed
-          b *= dimming;
-          g *= dimming;
-          r *= dimming;
-          b = b >> 8;
-          g = g >> 8;
-          r = r >> 8;
+          color = alphaBlend(dimming, color, TFT_BLACK);
         } // dimming
-*/        
-        UnpackedImageBuffer[row+y][col+x] = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xFF) >> 3);
+
+        UnpackedImageBuffer[row+y][col+x] = color;
     } // col
   } // row
   FileInBuffer = file_index;

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -295,6 +295,9 @@ void loop() {
         time_t offset = uclock.getTimeZoneOffset();
         int8_t offset_hour = offset/3600;
         int8_t offset_min = (offset%3600)/60;
+        if(offset_min < 0) {
+          offset_min = -offset_min;
+        }
         tfts.printf("%d:%02d\n", offset_hour, offset_min);
       }
       // UTC Offset, 15 minutes
@@ -313,6 +316,9 @@ void loop() {
         time_t offset = uclock.getTimeZoneOffset();
         int8_t offset_hour = offset/3600;
         int8_t offset_min = (offset%3600)/60;
+        if(offset_min < 0) {
+          offset_min = -offset_min;
+        }
         tfts.printf("%d:%02d\n", offset_hour, offset_min);
       }
       // select clock "font"

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -267,7 +267,7 @@ void loop() {
         }
         
         setupMenu();
-        tfts.println("12 Hour?");
+        tfts.println("Hour format");
         tfts.println(uclock.getTwelveHour() ? "12 hour" : "24 hour"); 
       }
       // Blank leading zeros on the hours?
@@ -319,8 +319,11 @@ void loop() {
       else if (menu_state == Menu::selected_graphic) {
         if (menu_change != 0) {
           uclock.adjustClockGraphicsIdx(menu_change);
-          tfts.current_graphic = uclock.getActiveGraphicIdx();
-          updateClockDisplay(TFTs::force);   // redraw everything
+
+          if(tfts.current_graphic != uclock.getActiveGraphicIdx()) {
+            tfts.current_graphic = uclock.getActiveGraphicIdx();
+            updateClockDisplay(TFTs::force);   // redraw everything
+          }
         }
 
         setupMenu();

--- a/EleksTubeHAX_pio/src/main.h
+++ b/EleksTubeHAX_pio/src/main.h
@@ -2,4 +2,4 @@
 
 void updateClockDisplay(TFTs::show_t show=TFTs::yes);
 void setupMenu();
-void EveryFullHour();
+void EveryFullHour(bool loopUpdate=false);


### PR DESCRIPTION
- Hour format menu: Change title to "Hour format", and when user changes, shows "12" or "24" format;
- Graphic change menu: Changed the behavior of the limits, when trying to advance beyond the displays, it returns to the initial one, when trying to return while being in the first one, it returns to the last one;
- Dimming: Allow bitmaps dimming using TFT_eSPI alphaBlend method;
- Clock: Adjusting time after change timezone;
- TFT: Improve display energy toggle, keeping screen black;
- Timezone: Improve TFT display update after a timezone update, mainly when dimming was toggle;
- Offset menu: Fix minutes offset display (was -1:-30, now it its -1:30);

