### PR TITLE
Fixed the deprecate method compiler warnings for the JSON parsing for MQTT messages

### DIFF
--- a/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
+++ b/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
@@ -466,7 +466,7 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
   }
   #endif
 
-  #ifdef MQTT_HOME_ASSISTANT
+#ifdef MQTT_HOME_ASSISTANT
   char message[length + 1];
   sprintf(message, "%c", (char)payload[0]);
   for (int i = 1; i < length; i++) {
@@ -476,20 +476,21 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
   Serial.print(topic);
   Serial.print(" ");
   Serial.println(message);
+
   if (strcmp(command[0], "main") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandMainPower = doc["state"] == MQTT_STATE_ON;
+    if(doc["state"].is<const char*>()) {
+      MqttCommandMainPower = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandMainPowerReceived = true;
     }
-    if(doc.containsKey("brightness")) {
+    if(doc["brightness"].is<int>()) {
        MqttCommandMainBrightness = doc["brightness"];
        MqttCommandMainBrightnessReceived = true;
      }
-    if(doc.containsKey("effect")) {
-      MqttCommandMainGraphic = tfts.nameToClockFace(doc["effect"]);   
+    if(doc["effect"].is<const char*>()) {
+      MqttCommandMainGraphic = tfts.nameToClockFace(doc["effect"]);
       MqttCommandMainGraphicReceived = true;
       }
 
@@ -499,75 +500,81 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandBackPower = doc["state"] == MQTT_STATE_ON;
+    if(doc["state"].is<const char*>()) {
+      MqttCommandBackPower = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandBackPowerReceived = true;
     }
-    if(doc.containsKey("brightness")) {
+    if(doc["brightness"].is<int>()) {    
       MqttCommandBackBrightness = doc["brightness"];
       MqttCommandBackBrightnessReceived = true;
     }
-    if(doc.containsKey("effect")) {
+    if(doc["effect"].is<const char*>()) {    
       strcpy(MqttCommandBackPattern, doc["effect"]);
       MqttCommandBackPatternReceived = true;
       }
-    if(doc.containsKey("color")) {
+    if(doc["color"].is<JsonObject>()) {
       MqttCommandBackColorPhase = backlights.hueToPhase(doc["color"]["h"]);   
       MqttCommandBackColorPhaseReceived = true;
       }
+    
     doc.clear();
   }
   if (strcmp(command[0], "use_twelve_hours") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandUseTwelveHours = doc["state"] == MQTT_STATE_ON;
+    if(doc["state"].is<const char*>()) {
+      MqttCommandUseTwelveHours = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandUseTwelveHoursReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "blank_zero_hours") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandBlankZeroHours = doc["state"] == MQTT_STATE_ON;
+    if(doc["state"].is<const char*>()) {
+      MqttCommandBlankZeroHours = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandBlankZeroHoursReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "pulse_bpm") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandPulseBpm = uint8_t(doc["state"]);
+    if(doc["state"].is<uint8_t>()) {
+      MqttCommandPulseBpm = doc["state"];
       MqttCommandPulseBpmReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "breath_bpm") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandBreathBpm = uint8_t(doc["state"]);
+    if(doc["state"].is<uint8_t>()) {
+      MqttCommandBreathBpm = doc["state"];
       MqttCommandBreathBpmReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "rainbow_duration") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
-      MqttCommandRainbowSec = float(doc["state"]);
+    if(doc["state"].is<float>()) {
+      MqttCommandRainbowSec = doc["state"];
       MqttCommandRainbowSecReceived = true;
     }
+
     doc.clear();
   }
-  #endif
+#endif
  }
 
 void MqttLoopFrequently(){

--- a/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
+++ b/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
@@ -466,7 +466,7 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
   }
   #endif
 
-#ifdef MQTT_HOME_ASSISTANT
+  #ifdef MQTT_HOME_ASSISTANT
   char message[length + 1];
   sprintf(message, "%c", (char)payload[0]);
   for (int i = 1; i < length; i++) {
@@ -476,7 +476,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
   Serial.print(topic);
   Serial.print(" ");
   Serial.println(message);
-
   if (strcmp(command[0], "main") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
@@ -516,7 +515,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandBackColorPhase = backlights.hueToPhase(doc["color"]["h"]);   
       MqttCommandBackColorPhaseReceived = true;
       }
-    
     doc.clear();
   }
   if (strcmp(command[0], "use_twelve_hours") == 0 && strcmp(command[1], "set") == 0) {
@@ -527,7 +525,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandUseTwelveHours = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandUseTwelveHoursReceived = true;
     }
-
     doc.clear();
   }
   if (strcmp(command[0], "blank_zero_hours") == 0 && strcmp(command[1], "set") == 0) {
@@ -538,7 +535,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandBlankZeroHours = strcmp(doc["state"], MQTT_STATE_ON) == 0;
       MqttCommandBlankZeroHoursReceived = true;
     }
-
     doc.clear();
   }
   if (strcmp(command[0], "pulse_bpm") == 0 && strcmp(command[1], "set") == 0) {
@@ -549,7 +545,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandPulseBpm = doc["state"];
       MqttCommandPulseBpmReceived = true;
     }
-
     doc.clear();
   }
   if (strcmp(command[0], "breath_bpm") == 0 && strcmp(command[1], "set") == 0) {
@@ -560,7 +555,6 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandBreathBpm = doc["state"];
       MqttCommandBreathBpmReceived = true;
     }
-
     doc.clear();
   }
   if (strcmp(command[0], "rainbow_duration") == 0 && strcmp(command[1], "set") == 0) {
@@ -571,10 +565,9 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
       MqttCommandRainbowSec = doc["state"];
       MqttCommandRainbowSecReceived = true;
     }
-
     doc.clear();
   }
-#endif
+  #endif
  }
 
 void MqttLoopFrequently(){


### PR DESCRIPTION
Fixed the deprecate method compiler warnings for the JSON parsing for MQTT messages.

containskey() method from ArduinoJSON is marked as deprecated and is now replaced in the code.

Tested with (and without) Home Assistant integration active.

See: https://arduinojson.org/v7/api/jsondocument/containskey/