### PR TITLE
Fixed timezone UI problems - Changed timezone set behavoir - changed dimming applying

### DIFF
--- a/EleksTubeHAX_pio/src/Backlights.h
+++ b/EleksTubeHAX_pio/src/Backlights.h
@@ -60,7 +60,7 @@ public:
   void adjustIntensity(int16_t adj);
   uint8_t getIntensity()                      { return config->intensity; }
 
-  bool dimming = false;
+  void setDimming(bool dim)                   { dimming = dim; pattern_needs_init = true; }
 
   // Helper methods
   uint32_t phaseToColor(uint16_t phase);
@@ -72,6 +72,7 @@ public:
   const uint8_t max_intensity = 8;  // 0 to 7
 
 private:
+  bool dimming = false;
   bool pattern_needs_init;
   bool off;
 


### PR DESCRIPTION
Please do a squash merge!

Fixed timezone UI problems -> 
Dimming was not applied correctly if timezone changed from the menu and reached night time/day time.
menu was not redrawn (so not visible anymore), if the tens hours digit changed while timezone set.

Changed timezone set behavoir ->
The timezone offset value is now "wrapped around" if -12 or +12 h is reached.

Changed timezone menu drawing ->
For negative values a minus (-) is drawn in front of the actual offset.
For positive values a plus (+) is drawn in front of the actual offset.
For 0:00 no sign at all.

minor changes in the serial/debug outputs and the code formatting

renamed and changed the variables and functions for dimming in main.cpp

added a public setDimming() method to Backlights class and put member variable "dimming" to private

placed all "auto night time dimming" stuff behind IFDEFs