### PR TITLE
Added different text colours to the setup sequence

### DIFF
--- a/EleksTubeHAX_pio/src/TFTs.cpp
+++ b/EleksTubeHAX_pio/src/TFTs.cpp
@@ -81,20 +81,20 @@ void TFTs::showNoMqttStatus() {
   }
 
 void TFTs::showTemperature() { 
-  #ifdef ONE_WIRE_BUS_PIN
-   if (fTemperature > -30) { // only show if temperature is valid
-      chip_select.setHoursOnes();
-      setTextColor(TFT_CYAN, TFT_BLACK);
-      fillRect(0, TFT_HEIGHT - 17, TFT_WIDTH, 17, TFT_BLACK);
-      setCursor(5, TFT_HEIGHT - 17, 2);  // Font 2. 16 pixel high
-      print("T: ");
-      print(sTemperatureTxt);
-      print(" C");
-   }
+#ifdef ONE_WIRE_BUS_PIN
+    if (fTemperature > -30) { // only show if temperature is valid
+        chip_select.setHoursOnes();
+        setTextColor(TFT_CYAN, TFT_BLACK);
+        fillRect(0, TFT_HEIGHT - 17, TFT_WIDTH, 17, TFT_BLACK);
+        setCursor(5, TFT_HEIGHT - 17, 2);  // Font 2. 16 pixel high
+        print("T: ");
+        print(sTemperatureTxt);
+        print(" C");
+    }
 #ifdef DEBUG_OUTPUT
     Serial.println("Temperature to LCD");
 #endif    
-  #endif
+#endif
 }
 
 void TFTs::setDigit(uint8_t digit, uint8_t value, show_t show) {

--- a/EleksTubeHAX_pio/src/TFTs.cpp
+++ b/EleksTubeHAX_pio/src/TFTs.cpp
@@ -81,20 +81,20 @@ void TFTs::showNoMqttStatus() {
   }
 
 void TFTs::showTemperature() { 
-#ifdef ONE_WIRE_BUS_PIN
-    if (fTemperature > -30) { // only show if temperature is valid
-        chip_select.setHoursOnes();
-        setTextColor(TFT_CYAN, TFT_BLACK);
-        fillRect(0, TFT_HEIGHT - 17, TFT_WIDTH, 17, TFT_BLACK);
-        setCursor(5, TFT_HEIGHT - 17, 2);  // Font 2. 16 pixel high
-        print("T: ");
-        print(sTemperatureTxt);
-        print(" C");
-    }
+  #ifdef ONE_WIRE_BUS_PIN
+   if (fTemperature > -30) { // only show if temperature is valid
+      chip_select.setHoursOnes();
+      setTextColor(TFT_CYAN, TFT_BLACK);
+      fillRect(0, TFT_HEIGHT - 17, TFT_WIDTH, 17, TFT_BLACK);
+      setCursor(5, TFT_HEIGHT - 17, 2);  // Font 2. 16 pixel high
+      print("T: ");
+      print(sTemperatureTxt);
+      print(" C");
+   }
 #ifdef DEBUG_OUTPUT
     Serial.println("Temperature to LCD");
 #endif    
-#endif
+  #endif
 }
 
 void TFTs::setDigit(uint8_t digit, uint8_t value, show_t show) {

--- a/EleksTubeHAX_pio/src/WiFi_WPS.cpp
+++ b/EleksTubeHAX_pio/src/WiFi_WPS.cpp
@@ -121,8 +121,8 @@ void WifiBegin()  {
       }
     }
   }
-#else
-  // NO WPS -- Try using hard coded credentials
+#else //NO WPS -- Try using hard coded credentials
+
   WiFi.begin(WIFI_SSID, WIFI_PASSWD); 
   WiFi.onEvent(WiFiEvent);
   unsigned long StartTime = millis();
@@ -139,13 +139,19 @@ void WifiBegin()  {
       return; // exit loop, exit procedure, continue clock startup
     }
   }
-#endif // WIFI_USE_WPS
+  
+#endif
+
  
   WifiState = connected;
+  
   tfts.println("\nConnected! IP:");
   tfts.println(WiFi.localIP());
-  Serial.println(); Serial.print("Connected to "); Serial.println(WiFi.SSID());
-  Serial.print("IP address: "); Serial.println(WiFi.localIP());
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(WiFi.SSID());
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());  
   delay(200);
 }
 
@@ -163,7 +169,7 @@ void WiFiStartWps() {
   sprintf(stored_config.config.wifi.ssid, ""); 
   sprintf(stored_config.config.wifi.password, ""); 
   stored_config.config.wifi.WPS_connected = 0x11; // invalid = different than 0x55
-  Serial.println(); Serial.print("Saving config! Triggered from WPS start...");
+  Serial.println(""); Serial.print("Saving config! Triggered from WPS start...");
   stored_config.save();
   Serial.println(" Done.");
    
@@ -183,7 +189,7 @@ void WiFiStartWps() {
 
   wpsInitConfig();
   esp_wifi_wps_enable(&wps_config);
-  esp_wifi_wps_start(0);
+  esp_wifi_wps_start(0);  
 
 
   // loop until connected
@@ -196,7 +202,8 @@ void WiFiStartWps() {
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   sprintf(stored_config.config.wifi.ssid, "%s", WiFi.SSID());
 //   memset(stored_config.config.wifi.ssid, '\0', sizeof(stored_config.config.wifi.ssid));
-//   strcpy(stored_config.config.wifi.ssid, WiFi.SSID());
+//   strcpy(stored_config.config.wifi.ssid, WiFi.SSID()); 
+     
   sprintf(stored_config.config.wifi.password, ""); // can't save a password from WPS
   stored_config.config.wifi.WPS_connected = StoredConfig::valid;
   Serial.println(); Serial.print("Saving config! Triggered from WPS success...");

--- a/EleksTubeHAX_pio/src/WiFi_WPS.cpp
+++ b/EleksTubeHAX_pio/src/WiFi_WPS.cpp
@@ -98,9 +98,9 @@ void WifiBegin()  {
   } else {
     // data is saved, connect now
     // WiFi credentials are known, connect
-    tfts.println("Joining wifi");
+    tfts.println("Joining WiFi");
     tfts.println(stored_config.config.wifi.ssid);
-    Serial.print("Joining wifi ");
+    Serial.print("Joining WiFi ");
     Serial.println(stored_config.config.wifi.ssid);
   
     // https://stackoverflow.com/questions/48024780/esp32-wps-reconnect-on-power-on
@@ -121,36 +121,31 @@ void WifiBegin()  {
       }
     }
   }
-#else   ////NO WPS -- Hard coded credentials
-
+#else
+  // NO WPS -- Try using hard coded credentials
   WiFi.begin(WIFI_SSID, WIFI_PASSWD); 
   WiFi.onEvent(WiFiEvent);
   unsigned long StartTime = millis();
   while ((WiFi.status() != WL_CONNECTED)) {
     delay(500);
-    tfts.print(".");
-    Serial.print(".");
+    tfts.print(">");
+    Serial.print(">");
     if ((millis() - StartTime) > (WIFI_CONNECT_TIMEOUT_SEC * 1000)) {
-      Serial.println("\r\nWiFi connection timeout!");
+      tfts.setTextColor(TFT_RED, TFT_BLACK);
       tfts.println("\nTIMEOUT!");
+      tfts.setTextColor(TFT_WHITE, TFT_BLACK);
+      Serial.println("\r\nWiFi connection timeout!");
       WifiState = disconnected;
       return; // exit loop, exit procedure, continue clock startup
     }
   }
-  
-#endif
-
+#endif // WIFI_USE_WPS
  
   WifiState = connected;
-
-  tfts.println("\n Connected!");
+  tfts.println("\nConnected! IP:");
   tfts.println(WiFi.localIP());
-  
-  Serial.println("");
-  Serial.print("Connected to ");
-  Serial.println(WiFi.SSID());
-  Serial.print("IP address: ");
-  Serial.println(WiFi.localIP());  
+  Serial.println(); Serial.print("Connected to "); Serial.println(WiFi.SSID());
+  Serial.print("IP address: "); Serial.println(WiFi.localIP());
   delay(200);
 }
 
@@ -168,7 +163,7 @@ void WiFiStartWps() {
   sprintf(stored_config.config.wifi.ssid, ""); 
   sprintf(stored_config.config.wifi.password, ""); 
   stored_config.config.wifi.WPS_connected = 0x11; // invalid = different than 0x55
-  Serial.print("Saving config.");
+  Serial.println(); Serial.print("Saving config! Triggered from WPS start...");
   stored_config.save();
   Serial.println(" Done.");
    
@@ -188,7 +183,7 @@ void WiFiStartWps() {
 
   wpsInitConfig();
   esp_wifi_wps_enable(&wps_config);
-  esp_wifi_wps_start(0);  
+  esp_wifi_wps_start(0);
 
 
   // loop until connected
@@ -199,13 +194,12 @@ void WiFiStartWps() {
     Serial.print(".");
   }
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
-  Serial.print("Saving config.");
-  sprintf(stored_config.config.wifi.ssid, "%s", WiFi.SSID()); 
+  sprintf(stored_config.config.wifi.ssid, "%s", WiFi.SSID());
 //   memset(stored_config.config.wifi.ssid, '\0', sizeof(stored_config.config.wifi.ssid));
-//   strcpy(stored_config.config.wifi.ssid, WiFi.SSID()); 
-     
+//   strcpy(stored_config.config.wifi.ssid, WiFi.SSID());
   sprintf(stored_config.config.wifi.password, ""); // can't save a password from WPS
   stored_config.config.wifi.WPS_connected = StoredConfig::valid;
+  Serial.println(); Serial.print("Saving config! Triggered from WPS success...");
   stored_config.save();
   Serial.println(" WPS finished."); 
 }

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -74,26 +74,30 @@ void setup() {
   buttons.begin();
   menu.begin();
 
-#ifdef HARDWARE_NovelLife_SE_CLOCK // NovelLife_SE Clone XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-  //Init the Gesture sensor
-  tfts.println("Gesture sensor start");
-  GestureStart(); //TODO put into class
-#endif
-
   // Setup the displays (TFTs) initaly and show bootup message(s)
   tfts.begin();  // and count number of clock faces available
   tfts.fillScreen(TFT_BLACK);
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   tfts.setCursor(0, 0, 2);  // Font 2. 16 pixel high
-  tfts.println("setup...");
+  tfts.println("Starting Setup...");
+
+#ifdef HARDWARE_NovelLife_SE_CLOCK // NovelLife_SE Clone XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  //Init the Gesture sensor
+  tfts.setTextColor(TFT_ORANGE, TFT_BLACK);
+  tfts.print("Gest start..."); Serial.print("Gesture Sensor start...");
+  GestureStart(); //TODO put into class
+  tfts.println("Done!"); Serial.println("Done!");
+  tfts.setTextColor(TFT_WHITE, TFT_BLACK);
+#endif
 
   // Setup WiFi connection. Must be done before setting up Clock.
   // This is done outside Clock so the network can be used for other things.
-//  WiFiBegin(&stored_config.config.wifi);
-  tfts.println("WiFi start");
+  tfts.setTextColor(TFT_DARKGREEN, TFT_BLACK);
+  tfts.println("WiFi start..."); Serial.println("WiFi start...");
   WifiBegin();
-  
-  // wait for a bit before querying NTP
+  tfts.setTextColor(TFT_WHITE, TFT_BLACK);
+
+  // wait a bit (5x100ms = 0.5 sec) before querying NTP
   for (uint8_t ndx=0; ndx < 5; ndx++) {
     tfts.print(">");
     delay(100);
@@ -101,25 +105,35 @@ void setup() {
   tfts.println("");
 
   // Setup the clock.  It needs WiFi to be established already.
-  tfts.println("Clock start");
+  tfts.setTextColor(TFT_MAGENTA, TFT_BLACK);
+  tfts.print("Clock start..."); Serial.print("Clock start...");
   uclock.begin(&stored_config.config.uclock);
+  tfts.println("Done!"); Serial.println("Done!");
+  tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
   // Setup MQTT
-  tfts.println("MQTT start");
+  tfts.setTextColor(TFT_YELLOW, TFT_BLACK);
+  tfts.print("MQTT start..."); Serial.print("MQTT start...");
   MqttStart();
+  tfts.println("Done!"); Serial.println("Done!");
+  tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
 #ifdef GEOLOCATION_ENABLED
-  tfts.println("Geoloc query");
+  tfts.setTextColor(TFT_NAVY, TFT_BLACK);
+  tfts.println("GeoLoc query..."); Serial.println("GeoLoc query...");
   if (GetGeoLocationTimeZoneOffset()) {
-    tfts.print("TZ: ");
-    tfts.println(GeoLocTZoffset);
+    tfts.print("TZ: "); Serial.print("TZ: ");
+    tfts.println(GeoLocTZoffset); Serial.println(GeoLocTZoffset);
     uclock.setTimeZoneOffset(GeoLocTZoffset * 3600);
-    Serial.print("Saving config...");
+    Serial.println(); Serial.print("Saving config! Triggerd by timezone change...");
     stored_config.save();
-    Serial.println(" Done.");
+    Serial.println("Done.");
+    tfts.println("Done!"); Serial.println("Done!");
+    tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   } else {
-    Serial.println("Geolocation failed.");    
-    tfts.println("Geo FAILED");
+    tfts.setTextColor(TFT_RED, TFT_BLACK);
+    tfts.println("GeoLoc FAILED"); Serial.println("GeoLoc failed!");
+    tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   }
 #endif
 
@@ -133,9 +147,10 @@ void setup() {
   }
   tfts.current_graphic = uclock.getActiveGraphicIdx();
 
-  tfts.println("Done with setup.");
+  tfts.setTextColor(TFT_WHITE, TFT_BLACK);
+  tfts.println("Done with Setup!"); Serial.println("Done with Setup!");
 
-  // Leave boot up messages on screen for a few seconds.
+  // Leave boot up messages on screen for a few seconds (10x200ms = 2 sec)
   for (uint8_t ndx=0; ndx < 10; ndx++) {
     tfts.print(">");
     delay(200);
@@ -144,7 +159,7 @@ void setup() {
   // Start up the clock displays.
   tfts.fillScreen(TFT_BLACK);
   uclock.loop();
-  updateClockDisplay(TFTs::force);
+  updateClockDisplay(TFTs::force); // Draw all the clock digits
   Serial.println("Setup finished.");
 }
 
@@ -383,8 +398,7 @@ void loop() {
 
   EveryFullHour(true); // night or daytime
 
-  // Update the clock.
-  updateClockDisplay();
+  updateClockDisplay(); // Draw only the changed clock digits!
   
   UpdateDstEveryNight();
 

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -84,16 +84,19 @@ void setup() {
 #ifdef HARDWARE_NovelLife_SE_CLOCK // NovelLife_SE Clone XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   //Init the Gesture sensor
   tfts.setTextColor(TFT_ORANGE, TFT_BLACK);
-  tfts.print("Gest start..."); Serial.print("Gesture Sensor start...");
+  tfts.print("Gest start...");
+  Serial.print("Gesture Sensor start...");
   GestureStart(); //TODO put into class
-  tfts.println("Done!"); Serial.println("Done!");
+  tfts.println("Done!");
+  Serial.println("Done!");
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 #endif
 
   // Setup WiFi connection. Must be done before setting up Clock.
   // This is done outside Clock so the network can be used for other things.
   tfts.setTextColor(TFT_DARKGREEN, TFT_BLACK);
-  tfts.println("WiFi start..."); Serial.println("WiFi start...");
+  tfts.println("WiFi start...");
+  Serial.println("WiFi start...");
   WifiBegin();
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
@@ -106,33 +109,42 @@ void setup() {
 
   // Setup the clock.  It needs WiFi to be established already.
   tfts.setTextColor(TFT_MAGENTA, TFT_BLACK);
-  tfts.print("Clock start..."); Serial.print("Clock start...");
+  tfts.print("Clock start...");
+  Serial.print("Clock start...");
   uclock.begin(&stored_config.config.uclock);
-  tfts.println("Done!"); Serial.println("Done!");
+  tfts.println("Done!");
+  Serial.println("Done!");
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
   // Setup MQTT
   tfts.setTextColor(TFT_YELLOW, TFT_BLACK);
-  tfts.print("MQTT start..."); Serial.print("MQTT start...");
+  tfts.print("MQTT start...");
+  Serial.print("MQTT start...");
   MqttStart();
-  tfts.println("Done!"); Serial.println("Done!");
+  tfts.println("Done!");
+  Serial.println("Done!");
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
 
 #ifdef GEOLOCATION_ENABLED
   tfts.setTextColor(TFT_NAVY, TFT_BLACK);
-  tfts.println("GeoLoc query..."); Serial.println("GeoLoc query...");
+  tfts.println("GeoLoc query...");
+  Serial.println("GeoLoc query...");
   if (GetGeoLocationTimeZoneOffset()) {
-    tfts.print("TZ: "); Serial.print("TZ: ");
-    tfts.println(GeoLocTZoffset); Serial.println(GeoLocTZoffset);
+    tfts.print("TZ: ");
+    Serial.print("TZ: ");
+    tfts.println(GeoLocTZoffset);
+    Serial.println(GeoLocTZoffset);
     uclock.setTimeZoneOffset(GeoLocTZoffset * 3600);
-    Serial.println(); Serial.print("Saving config! Triggerd by timezone change...");
-    stored_config.save();
-    Serial.println("Done.");
-    tfts.println("Done!"); Serial.println("Done!");
+    Serial.println();
+    Serial.print("Saving config! Triggerd by timezone change...");
+    stored_config.save();    
+    tfts.println("Done!");
+    Serial.println("Done!");
     tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   } else {
     tfts.setTextColor(TFT_RED, TFT_BLACK);
-    tfts.println("GeoLoc FAILED"); Serial.println("GeoLoc failed!");
+    tfts.println("GeoLoc FAILED");
+    Serial.println("GeoLoc failed!");
     tfts.setTextColor(TFT_WHITE, TFT_BLACK);
   }
 #endif
@@ -148,7 +160,8 @@ void setup() {
   tfts.current_graphic = uclock.getActiveGraphicIdx();
 
   tfts.setTextColor(TFT_WHITE, TFT_BLACK);
-  tfts.println("Done with Setup!"); Serial.println("Done with Setup!");
+  tfts.println("Done with Setup!");
+  Serial.println("Done with Setup!");
 
   // Leave boot up messages on screen for a few seconds (10x200ms = 2 sec)
   for (uint8_t ndx=0; ndx < 10; ndx++) {


### PR DESCRIPTION
The initial setup sequence now displays different initialization parts in different colors.

In case of an error, the text turns red, for example, when a Wi-Fi connection error occurs.

The gesture initialization part has been moved after the TFT class initialization to allow for display output (which also fixes a bug).

Any output to the displays is now also sent to the serial interface.

Some output texts and formats have been adjusted (removed or added whitespace and line breaks, capitalized "WiFi," appended "... triggered by..." to save configuration printouts, and reordered printouts).

Some comments have been added or modified.