### PR TITLE
Added GitHub workflow to build and publish all firmware

### DIFF
--- a/.github/workflows/pio-build-and-publish-all-firmware-files.yml
+++ b/.github/workflows/pio-build-and-publish-all-firmware-files.yml
@@ -1,0 +1,131 @@
+name: EleksTubeHAX generate firmware files
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'EleksTubeHAX_pio/**'
+  workflow_dispatch:
+
+jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.set_version.outputs.VERSION }}
+    steps:
+      - name: Set version number
+        id: set_version
+        run: |
+          MAJOR_VERSION=1
+          MINOR_VERSION=0
+          BUILD_NUMBER=${{ github.run_number }}
+          VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_NUMBER}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+  build-firmware:
+    needs: set-version
+    strategy:
+      matrix:
+        hardware: ['Elekstube_CLOCK', 'Elekstube_CLOCK_Gen2', 'SI_HAI_CLOCK', 'NovelLife_SE_CLOCK', 'PunkCyber_CLOCK']
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.set-version.outputs.VERSION }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.platformio/.cache
+        key: ${{ runner.os }}-pio
+      
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Modify _USER_DEFINES.h file
+      run: |
+        echo "Copy _USER_DEFINES - empty.h to _USER_DEFINES.h"
+        cp "./EleksTubeHAX_pio/src/_USER_DEFINES - empty.h" "./EleksTubeHAX_pio/src/_USER_DEFINES.h"
+        echo "Modify _USER_DEFINES.h for hardware: ${{ matrix.hardware }}"
+        python3 ./EleksTubeHAX_pio/script_modify_user_defines.py "${{ matrix.hardware }}"
+        echo "Modified _USER_DEFINES.h content:"
+        cat "./EleksTubeHAX_pio/src/_USER_DEFINES.h"
+
+    - name: Update FIRMWARE_VERSION in GLOBAL_DEFINES.h
+      run: |
+        echo "Updating FIRMWARE_VERSION in GLOBAL_DEFINES.h"
+        echo "Version: $VERSION"
+        sed -i "s/\(FIRMWARE_VERSION.*v\)1\.0/\1$VERSION/" "./EleksTubeHAX_pio/src/GLOBAL_DEFINES.h"
+        echo "Modified FIRMWARE_VERSION:"
+        grep '^#define FIRMWARE_VERSION' "./EleksTubeHAX_pio/src/GLOBAL_DEFINES.h"
+
+    - name: Install PlatformIO Core
+      run: pip install --upgrade platformio
+    
+    - name: Uncomment CREATE_FIRMWAREFILE in platformio.ini
+      run: |
+        echo "Uncomment CREATE_FIRMWAREFILE in platformio.ini!"
+        sed -i 's/; -D CREATE_FIRMWAREFILE/-D CREATE_FIRMWAREFILE/' "./EleksTubeHAX_pio/platformio.ini"
+        # Debug output
+        echo "Modified platformio.ini content:"
+        cat "./EleksTubeHAX_pio/platformio.ini"
+
+    - name: Build PlatformIO Project for 4MB flash
+      run: pio run --environment esp32dev
+      working-directory: ./EleksTubeHAX_pio
+
+    - name: Rename firmware files
+      run: |
+        cd EleksTubeHAX_pio/.pio/build/esp32dev/
+        echo "Rename firmware files!"
+        if [ "${{ matrix.hardware }}" = "Elekstube_CLOCK" ]; then
+          echo "move *_combined.bin to FW_Elekstube_HAX_${{ env.VERSION }}_original.bin"
+          mv *_combined.bin "FW_Elekstube_HAX_${{ env.VERSION }}_original.bin"
+        elif [ "${{ matrix.hardware }}" = "Elekstube_CLOCK_Gen2" ]; then
+          echo "move *_combined.bin to FW_Elekstube_HAX_${{ env.VERSION }}_Gen2-1.bin"
+          mv *_combined.bin "FW_Elekstube_HAX_${{ env.VERSION }}_Gen2-1.bin"
+        elif [ "${{ matrix.hardware }}" = "SI_HAI_CLOCK" ]; then
+          echo "move *_combined.bin to FW_SI_HAI_CLOCK_HAX_${{ env.VERSION }}.bin"
+          mv *_combined.bin "FW_SI_HAI_CLOCK_HAX_${{ env.VERSION }}.bin"
+        elif [ "${{ matrix.hardware }}" = "NovelLife_SE_CLOCK" ]; then
+          echo "move *_combined.bin to FW_NovelLife_SE_HAX_${{ env.VERSION }}.bin"
+          mv *_combined.bin "FW_NovelLife_SE_HAX_${{ env.VERSION }}.bin"
+        elif [ "${{ matrix.hardware }}" = "PunkCyber_CLOCK" ]; then
+          echo "move *_combined.bin to FW_PunkCyber_Glow_PCBway_HAX_${{ env.VERSION }}.bin"
+          mv *_combined.bin "FW_PunkCyber_Glow_PCBway_HAX_${{ env.VERSION }}.bin"
+        fi
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware-${{ matrix.hardware }}
+        path: |
+          EleksTubeHAX_pio/.pio/build/esp32dev/FW_*.bin
+        if-no-files-found: error
+
+  combine-artifacts:
+    needs: [set-version, build-firmware]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.set-version.outputs.VERSION }}
+    steps:
+      - name: Check VERSION
+        run: |        
+          echo "VERSION=$VERSION"
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-firmware
+          pattern: firmware-*
+          merge-multiple: true
+
+      - name: Upload combined artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-firmware-v${{ env.VERSION }}
+          path: all-firmware/**/*.bin
+          if-no-files-found: error

--- a/EleksTubeHAX_pio/platformio.ini
+++ b/EleksTubeHAX_pio/platformio.ini
@@ -14,8 +14,8 @@ board = esp32dev
 framework = arduino
 
 build_flags =
-	-DCORE_DEBUG_LEVEL=5	; Set to 0 for no debug; saves flash memory
-							; Set to 5 for full debug
+	-DCORE_DEBUG_LEVEL=5	; Set to 0 for no debug; saves flash memory; Set to 5 for full debug
+	; -D CREATE_FIRMWAREFILE	; "activate" the extra_script script_build_fs_and_merge.py
 
 ; https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html
 board_build.partitions = partition_noOta_1Mapp_3Mspiffs.csv
@@ -38,7 +38,7 @@ lib_deps =
 	; These libraries and source files are causing boot-loop-crash. Do not use. TO-DO: replace with different libraries and source files.
 	;milesburton/DallasTemperature
 	;OneWire
-		
+
 ; === Tested and working with following versions. If you have issues, revert to libraries listed below. ===
 ; arduino-libraries/NTPClient@^3.2.1
 ; adafruit/Adafruit NeoPixel@^1.12.0
@@ -56,4 +56,5 @@ extra_scripts =
 	script_configure_tft_lib.py
 	; modify the library files from the APDS9660 gesture sensor library to match ID if the used sensor
     script_adjust_gesture_sensor_lib.py 
- 
+	; build the filesystem image and merge it with the other firmware files to one combinded binary with the name of the defined hardware in name
+	script_build_fs_and_merge.py

--- a/EleksTubeHAX_pio/script_build_fs_and_merge.py
+++ b/EleksTubeHAX_pio/script_build_fs_and_merge.py
@@ -1,0 +1,252 @@
+# script_build_fs_and_merge.py
+
+import os
+import subprocess
+import sys
+import csv
+import re
+from os import getenv
+from SCons.Script import Import, DefaultEnvironment
+
+def is_create_firmwarefile_defined():
+    for define in cpp_defines:
+        if isinstance(define, str) and define == 'CREATE_FIRMWAREFILE':
+            return True
+        elif isinstance(define, tuple) and define[0] == 'CREATE_FIRMWAREFILE':
+            return True
+    return False
+
+def parse_partition_table(partition_csv_path):
+    """
+    Parses the partition table CSV file and extracts offsets for bootloader, partition table,
+    app (firmware), and spiffs.
+
+    :param partition_csv_path: Path to the partition table CSV file.
+    :return: Dictionary with offsets for 'bootloader', 'partition_table', 'app0' or 'factory', and 'spiffs'.
+    """
+    offsets = {}
+
+    # Standard offsets for bootloader and partition table
+    offsets['bootloader'] = '0x1000'
+    offsets['partition_table'] = '0x8000'
+
+    if not os.path.isfile(partition_csv_path):
+        print(f"[Error] Partition table file not found: {partition_csv_path}")
+        env.Exit(1)
+
+    with open(partition_csv_path, newline='') as csvfile:
+        reader = csv.reader(csvfile, delimiter=',')
+        for row in reader:
+            # Skip comments and empty lines
+            if not row or row[0].startswith('#'):
+                continue
+            if len(row) < 5:
+                continue  # Not enough columns
+            name = row[0].strip()
+            offset = row[3].strip()
+            # Store offsets for 'app0', 'factory', and 'spiffs'
+            if name.lower() in ['app0', 'factory', 'spiffs']:
+                # Convert offset from hex or decimal string to integer
+                try:
+                    offset_int = int(offset, 0)
+                    offsets[name.lower()] = hex(offset_int)
+                except ValueError:
+                    print(f"[Error] Invalid offset value for partition '{name}': {offset}")
+                    env.Exit(1)
+
+    # Verify that required partitions were found
+    required_partitions = ['app0', 'factory', 'spiffs']
+    if not any(partition in offsets for partition in ['app0', 'factory']):
+        print("[Error] Required partition 'app0' or 'factory' not found in partition table.")
+        env.Exit(1)
+    if 'spiffs' not in offsets:
+        print("[Error] Required partition 'spiffs' not found in partition table.")
+        env.Exit(1)
+
+    return offsets
+
+def extract_hardware_name(user_defines_path):
+    """
+    Extracts the active hardware name from the _User_defines.h file.
+
+    :param user_defines_path: Path to the _User_defines.h file.
+    :return: Hardware name as a string.
+    """
+    if not os.path.isfile(user_defines_path):
+        print(f"[Error] _User_defines.h file not found: {user_defines_path}")
+        env.Exit(1)
+
+    with open(user_defines_path, 'r') as f:
+        lines = f.readlines()
+
+    in_hardware_section = False
+    hardware_name = None
+
+    for line in lines:
+        stripped_line = line.strip()
+
+        # Check if we've reached the "Type of the clock hardware" section
+        if 'Type of the clock hardware' in stripped_line:
+            in_hardware_section = True
+            continue  # Move to the next line
+
+        if in_hardware_section:
+            # If we encounter an empty line or a comment that marks the end of the section, exit the section
+            if stripped_line == '' or 'End of hardware types' in stripped_line:
+                break
+
+            # Ignore commented lines (single-line comments)
+            if stripped_line.startswith('//') or stripped_line.startswith('/*') or stripped_line.startswith('*'):
+                continue
+
+            # Ignore lines that have inline comments
+            line_without_comments = line.split('//')[0].split('/*')[0].strip()
+
+            # Match the #define statement
+            define_match = re.match(r'#define\s+(HARDWARE_\w+)', line_without_comments)
+            if define_match:
+                hardware_name = define_match.group(1)
+                break  # Found the active hardware define
+
+    if hardware_name:
+        return hardware_name
+    else:
+        print("[Error] Active hardware define not found in the 'Type of the clock hardware' section.")
+        env.Exit(1)
+
+def run_buildfs(source, target, env):
+    print("\n[Post-Build] Starting SPIFFS build...")
+    
+    # Build the SPIFFS filesystem
+    buildfs_cmd = [
+        env.subst("$PYTHONEXE"),
+        "-m",
+        "platformio",
+        "run",
+        "--target",
+        "buildfs"
+    ]
+    
+    result = subprocess.run(buildfs_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    
+    if result.returncode != 0:
+        print("[Post-Build] Failed to build SPIFFS filesystem.")
+        print(result.stderr)
+        sys.exit(1)
+    else:
+        print("[Post-Build] Successfully built SPIFFS filesystem.")
+
+def run_merge_bins(source, target, env):
+    print("\n[Post-Build] Starting binary merge...")
+
+    platform = env.PioPlatform()
+
+    # Paths to binaries
+    firmware_bin = os.path.join(build_dir, "firmware.bin")
+    spiffs_bin = os.path.join(build_dir, "spiffs.bin")
+    combined_bin = os.path.join(build_dir, "combined.bin")
+    bootloader_bin = os.path.join(build_dir, "bootloader.bin")
+    partition_bin = os.path.join(build_dir, "partitions.bin")
+
+    # Path to the partition table CSV
+    partition_csv = env.GetProjectOption("board_build.partitions")
+    if not partition_csv:
+        print("[Error] 'board_build.partitions' not defined in platformio.ini.")
+        env.Exit(1)
+
+    partition_csv_path = partition_csv
+    if not os.path.isabs(partition_csv_path):
+        partition_csv_path = os.path.join(env.subst("$PROJECT_DIR"), partition_csv_path)
+
+    # Parse the partition table to get offsets
+    offsets = parse_partition_table(partition_csv_path)
+    bootloader_offset = offsets.get('bootloader', '0x1000')
+    partition_table_offset = offsets.get('partition_table', '0x8000')
+    app_partition_name = 'app0' if 'app0' in offsets else 'factory'
+    app_offset = offsets[app_partition_name]
+    spiffs_offset = offsets['spiffs']
+
+    # Extract hardware name for renaming the combined binary
+    user_defines_path = os.path.join(env.subst("$PROJECT_SRC_DIR"), "_USER_DEFINES.h")
+    hardware_name = extract_hardware_name(user_defines_path)
+    print(f"[Post-Build] Hardware name before santization: {hardware_name}")
+    if hardware_name:
+        # Create a sanitized hardware name for the filename
+        hardware_name_sanitized = hardware_name.replace("HARDWARE_", "")
+        hardware_name_sanitized = re.sub(r'\W+', '_', hardware_name_sanitized)
+    else:
+        hardware_name_sanitized = "UnknownHardware"
+
+    print(f"[Post-Build] Hardware name: {hardware_name_sanitized}")
+
+    # Define the output merged binary path with the hardware name
+    combined_bin_name = f"{hardware_name_sanitized}_combined.bin"
+    combined_bin = os.path.join(build_dir, combined_bin_name)
+    print(f"[Post-Build] Combined binary path: {combined_bin}")
+
+    # Check if all binaries exist
+    binaries = [
+        (bootloader_bin, "Bootloader binary"),
+        (partition_bin, "Partition table binary"),
+        (firmware_bin, "Firmware binary"),
+        (spiffs_bin, "SPIFFS binary")
+    ]
+
+    for bin_path, description in binaries:
+        if not os.path.isfile(bin_path):
+            print(f"[Error] {description} not found: {bin_path}")
+            env.Exit(1)
+
+    # Locate esptool.py
+    esptool_dir = platform.get_package_dir("tool-esptoolpy")
+    esptool_py = os.path.join(esptool_dir, "esptool.py")
+
+    if not os.path.isfile(esptool_py):
+        print(f"[Error] esptool.py not found at: {esptool_py}")
+        env.Exit(1)
+    else:
+        print(f"[Post-Build] Found esptool.py at: {esptool_py}")
+
+    # Merge binaries using esptool.py with offsets
+    merge_cmd = [
+        env.subst("$PYTHONEXE"),
+        esptool_py,
+        "--chip", "esp32",
+        "merge_bin",
+        "-o", combined_bin,
+        bootloader_offset, bootloader_bin,
+        partition_table_offset, partition_bin,
+        app_offset, firmware_bin,
+        spiffs_offset, spiffs_bin
+    ]
+
+    print(f"[Post-Build] Merging binaries into {combined_bin}...")
+    result = subprocess.run(merge_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if result.returncode != 0:
+        print("[Error] Failed to merge binaries.")
+        print(result.stderr)
+        env.Exit(1)
+    else:
+        print(f"[Post-Build] Successfully created {combined_bin}")
+
+# Initialize the build environment
+env = DefaultEnvironment()
+
+# Retrieve the build defines
+cpp_defines = env.get('CPPDEFINES', [])
+
+runscript = False
+runscript = is_create_firmwarefile_defined()
+
+if runscript:
+    print("===== Firmware file creation =====")
+    print("[Post-Build] CREATE_FIRMWAREFILE is defined. Registering post-build actions.")
+    # Retrieve build directory and environment name
+    build_dir = env.subst("$BUILD_DIR")
+    env_name = env.subst("$PIOENV")
+    # Register the post-build actions
+    env.AddPostAction("buildprog", [run_buildfs, run_merge_bins])
+# else:
+#     print("===== Firmware file creation =====")
+#     print("[Post-Build] CREATE_FIRMWAREFILE is not defined. Skipping firmware merge.")

--- a/EleksTubeHAX_pio/script_modify_user_defines.py
+++ b/EleksTubeHAX_pio/script_modify_user_defines.py
@@ -1,0 +1,54 @@
+# EleksTubeHAX_pio/script_modify_user_defines.py
+
+import sys
+import os
+import re
+
+def modify_user_defines(hardware_name, user_defines_path):
+    with open(user_defines_path, 'r') as file:
+        lines = file.readlines()
+
+    new_lines = []
+    in_hardware_section = False
+
+    for line in lines:
+        stripped_line = line.strip()
+
+        # Detect the start of the hardware section
+        if stripped_line.startswith('// ************* Type of the clock hardware'):
+            in_hardware_section = True
+
+        if in_hardware_section:
+            # Comment out all hardware defines
+            if re.match(r'^#define\s+HARDWARE_', stripped_line):
+                if not line.lstrip().startswith('//'):
+                    line = '//' + line
+                    # Update stripped_line after modifying line
+                    stripped_line = line.strip()
+
+            # Uncomment the specific hardware define
+            hardware_define_pattern = rf'^//\s*#define\s+HARDWARE_{re.escape(hardware_name)}\b'
+            if re.match(hardware_define_pattern, stripped_line):
+                line = line.replace('//', '', 1)
+                # Update stripped_line after modifying line
+                stripped_line = line.strip()
+                in_hardware_section = False  # Exit after uncommenting the hardware define
+
+            # End of hardware section
+            if stripped_line.endswith('Type of the clock hardware *************'):
+                in_hardware_section = False
+
+        new_lines.append(line)
+
+    with open(user_defines_path, 'w') as file:
+        file.writelines(new_lines)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python script_modify_user_defines.py <HARDWARE_NAME>")
+        sys.exit(1)
+
+    hardware_name = sys.argv[1]
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    user_defines_path = os.path.join(script_dir, 'src', '_USER_DEFINES.h')
+    modify_user_defines(hardware_name, user_defines_path)


### PR DESCRIPTION
- Added GitHub Actions workflow to build and publish all firmware files if content in the folder "EleksTubeHax_pio" in the main branch is updated
 - Added helper scripts
 - Added switch and scripts in platformio.ini
 - replaced esptool.exe with a never version to be able to merge files locally on windows (option merge_bin was missing)

1. **GitHub Actions Workflow (`pio-build-and-publish-all-firmware-files.yml`)**:
    - **New Workflow**: Added a GitHub Actions workflow to automate the process of generating firmware files.
    - **Triggers**: The workflow is triggered on pushes to the `main` branch in the ```ElekstubeHAX_pio``` subfolder and manual dispatch.
    - **Set Version Job**: Introduced a job to set the version number based on the GitHub run number.
    - **Build Firmware Job**: Added a job to build firmware for multiple hardware configurations using a matrix strategy.

2. **Configuration and Scripts**:
    - **Configuration**:
        - **```platformio.ini```**:
            - Added a build_flag ```-D CREATE_FIRMWAREFILE``` to enable local firmware generation.
           - Added script "script_build_fs_and_merge.py" under "extra_scripts" to trigger the build of the filesystem image and merge. This script only runs if the CREATE_FIRMWAREFILE flag is set in the build_flags.
    - **Scripts**:
        - **```script_build_fs_and_merge.py```**: 
          - Build the SPIFFS filesystem (because it is not triggered automatically when default build target is called in PIO).
          - Merge all build binaries into a valid flashable firmware image.
          - Use partition table CSV files to get the correct offsets.
          - Generate output file names based on the defined hardware.
          - The script only runs if the CREATE_FIRMWAREFILE flag is set in the build_flags.
        - **```script_modify_user_defines.py```**: 
          - This script rewrites the USER_DEFINES.h on the fly to switch hardware defines.

**Versioning**:

- The version number is generated based on a hard-defined major and minor version (1.0) + the workflow run number.
- It's then injected into both GLOBAL_DEFINES.h (in the existing version string) and individual firmware files.
- The version information is also added to the All-firmwaresX.zip archive.

**Advantages**: 
- All pre-built firmware files for supported hardware are generated automatically and available for download, review, or inclusion in releases.
- Users have access to actual firmware files even if not checked into the repository.
- Versioning based on run numbers guarantees unique versions.
- Users can build complete flashable firmware locally by uncommenting a line in platformio.ini.
- Public GitHub projects currently have no known limitations on running time or storage usage, so building on every commit shouldn't be an issue. The default retention time for artifacts is 90 days.

**Disadvantages**: 
- To use a matrix build strategy, intermediate build results must be published as separate artifacts alongside the All-firmwaresX.zip file.
- The mechanism relies on the existing file structure and keyword detection. Changes in file structure may require refactoring.
- New hardware or changed major or minor version numbers needs to be defined in the workflow to be included in the build process.

**esptool.exe Update**:
- A newer version of esptool.exe (v4.7.0) wasn't strictly necessary as the Python version bundled with PlatformIO is used. However, having the ability to use it manually from the command line is beneficial.
- The provided version is built for Windows x64 from the original Espressif sources and includes correct file version information.

TODO: Add documentation in the Readme.md.