### PR TITLE
FIX for a commit without a PR! - Orginal: Add GitHub Release workflow and update related files

### DIFF
--- a/.github/workflows/pio-build-and-create-github-release.yml
+++ b/.github/workflows/pio-build-and-create-github-release.yml
@@ -1,4 +1,4 @@
-name: Build & Create GitHub Release
+name: Build & Create GitHub Release 
 
 on:
   push:

--- a/.github/workflows/pio-build-and-publish-all-firmware-files.yml
+++ b/.github/workflows/pio-build-and-publish-all-firmware-files.yml
@@ -1,4 +1,4 @@
-name: Build & publish combined EleksTubeHAX firmware binaries.
+name: Build & publish combined EleksTubeHAX firmware binaries 
 
 on:
   pull_request:

--- a/.github/workflows/pio-build-multi-platform.yml
+++ b/.github/workflows/pio-build-multi-platform.yml
@@ -1,4 +1,4 @@
-name: Build all PIO environments on multiple OSes.
+name: Build all PIO environments on multiple OSes 
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EleksTubeHAX - An aftermarket custom firmware for the desk clock
+# EleksTubeHAX - An aftermarket custom firmware for the desk clock 
 
 ![EleksTube IPS clock](/docs/ImagesMD/EleksTube_IPS_Classic_Edition.jpg)
 
@@ -1015,7 +1015,7 @@ See also the code comments for more info in the `GLOBAL_DEFINES.h` for the IPSTu
 
 IPSTube clocks use slower Winbond flash chips that require conservative SPI settings (DIO mode at 40 MHz instead of QIO at 80 MHz). These slower flash chips provide only half the throughput of standard ESP32 flash memory, which results in slower loading times for the high-quality digit images and therefore slower display refresh rates compared to other clock models. Additionally, attempting to use QIO mode (quad I/O with four data lines which ARE connected on the PCB) or higher frequencies like 80 MHz (DIO or QIO) causes system instability with these chips.
 
-In normal operation this is barely noticeable, but becomes very apparent when multiple different digits need to be drawn simultaneously (cold load without prefetch).
+In normal operation this is barely noticeable, but becomes very apparent when multiple different digits need to be drawn simultaneously (cold load without prefetch) 
 
 ##### 6.5 LED strip on the bottom for some IPSTube clocks
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,4 +1,4 @@
-# EleksTubeHAX - An aftermarket custom firmware for the desk clock
+# EleksTubeHAX - An aftermarket custom firmware for the desk clock 
 
 ## 1. Pre-built firmware files
 


### PR DESCRIPTION
I accidentally merged a branch into main without creating a PR!
I’m very sorry about that!
I didn’t realize the upstream was pointing to the original repository.
The files now only contain whitespace changes in the first line, just to indicate that they have been modified.
The files are already changed! So I try to describe the changes exactly here.

Here is the originally planned PR comment:

## Add GitHub Release workflow and update related files

### Motivation

Previously there was no automated way to create an official **GitHub Release** with firmware binaries attached. Firmware updates were only available as temporary **GitHub Actions artifacts** — these expire after 90 days, require a GitHub login to download, and are buried under workflow run pages that are not user-friendly. There was no stable, public download link to share with users.

This PR introduces a dedicated release workflow that produces **permanent, publicly accessible downloads** via the GitHub Releases page, while cleaning up the responsibilities of the existing workflows.

---

### What changed

#### New: `.github/workflows/pio-build-and-create-github-release.yml`

A new workflow that:

- **Triggers** either on a version tag push (`v*`, e.g. `v1.3.10`) or manually via `workflow_dispatch` with a custom tag name.
- **Discovers** all PlatformIO environments automatically from `platformio.ini` — no manual list to maintain.
- **Builds** every clock variant in parallel on `ubuntu-latest`, with `CREATE_FIRMWAREFILE` enabled so the full merged binary (`FW_*.bin` — app + filesystem + bootloader) is produced.
- **Collects** all `FW_*.bin` files as individual per-environment artifacts and then merges them in the `release` job.
- **Generates** structured release notes automatically, including:
  - A hardware variant table describing each clock model
  - Flash instructions and limitations of pre-built images (WPS-only, no MQTT, fixed clock faces)
  - A backup reminder
  - A changelog since the previous tag (git log)
  - A link to `firmware/README.md` for detailed flashing guidance
- **Creates** the GitHub Release with `gh release create`, attaching all `FW_*.bin` files directly. Tags matching `*-rc*`, `*-beta*` or `*-alpha*` are automatically marked as pre-release.

#### Modified: `.github/workflows/pio-build-and-publish-all-firmware-files.yml`

- **Removed** the `push: branches: [main]` trigger — this workflow no longer runs on every commit to `main`. Continuous release publishing is now the job of the new release workflow.
- **Kept** `pull_request` and `workflow_dispatch` triggers so the workflow still serves as a **build-check for PRs** and can be triggered manually. Comments in the YAML clarify this intent.
- **Updated** all GitHub Actions versions: `checkout@v4→v6`, `setup-python@v5→v6`, `upload-artifact@v4→v7`, `download-artifact@v4→v8`.

#### Modified: `.github/workflows/pio-build-multi-platform.yml`

- **Updated** Windows runner from `windows-latest` to `windows-2025-vs2026` with an explanatory comment, because `windows-latest` will be deprecated by June 2026.
- **Updated** `checkout@v4→v6`, `setup-python@v5→v6`.
- Minor cleanup: removed trailing whitespace in the matrix block, shortened the workflow name.

#### Modified: `README.md` (section 4.3)

- Fixed typo: "pre-builded" → "pre-built"
- Updated the description to point users directly to the **Releases page** as the primary download location instead of navigating the firmware subdirectory manually.
- Updated bullet "How to get the newest image" → "How to flash the firmware file".

#### Modified: `firmware/README.md` (section 5)

- **Replaced** the previous instructions (which described how to navigate GitHub Actions workflow runs and download expiring artifacts) with a simple link to the **Releases page**.
- Removed references to outdated screenshots (`GitHubActionsOverview.png`, `GitHubActionsArtifactView.png`).
- Added a note at the top of the firmware section pointing to the Releases page as the canonical download location.

---

### Why this is better than before

| | Before | After |
|---|---|---|
| Download link | Buried in Actions → workflow run → artifact | Stable URL: `github.com/.../releases` |
| Login required | Yes (GitHub login needed for artifacts) | No (public releases are accessible without login) |
| Expiry | 90 days | Never |
| Release notes | None | Auto-generated with changelog, variant table, flash instructions |
| Trigger | Every push to `main` (noisy) | Only on version tags or manual dispatch |
| Actions versions | Outdated (v4/v5) | Current (v6/v7/v8) |
| Windows runner | `windows-latest` (deprecated June 2026) | `windows-2025-vs2026` |
